### PR TITLE
Add documentation from BrainFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Introduction
+# OpenVisionCapsules
+
+[![Documentation Status](https://readthedocs.org/projects/openvisioncapsules/badge/?version=latest)](https://openvisioncapsules.readthedocs.io/en/latest/?badge=latest)
 
 This repository contains the OpenVisionCapsules SDK, a set of Python libraries
 for encapsulating machine learning and computer vision algorithms for
@@ -24,6 +26,8 @@ suggestions, please open an issue.
 
 # Getting Started
 
+Take a look at the [documentation here][docs].
+
 A couple example capsules are available under `vcap/examples`, demonstrating
 how to create classifier and detector capsules from TensorFlow models.
 
@@ -43,3 +47,5 @@ To make use of the example capsules in the `vcap/examples/` directory, make
 sure to run the tests with pytest (from the root of the repo). The tests
 download all the necessary models and images, including the models for the 
 example capsules.
+
+[docs]: https://openvisioncapsules.readthedocs.io/en/latest/

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,99 @@
+## Introduction
+
+A backend is what provides the low-level analysis on a video frame. For machine
+learning, this is the place where the frame would be fed into the model and the
+results would be returned. Every capsule must define a backend class that
+subclasses the BaseBackend class. 
+
+The application will create an instance of the backend class for each device
+string returned by the capsule's device mapper. 
+
+## Required Methods
+
+All backends must subclass the BaseBackend abstract base class, meaning that
+there are a couple methods that the backend must implement.
+
+### process_frame
+
+```python
+DETECTION_NODE_TYPE = Union[None, DetectionNode, List[DetectionNode]]
+
+def process_frame(
+        self,
+        frame: np.ndarray,
+        detection_node: DETECTION_NODE_TYPE,
+        options: Dict[str, OPTION_TYPE],
+        state: BaseStreamState) -> DETECTION_NODE_TYPE:
+    ...
+```
+
+A method that does the preprocessing, inference, and postprocessing
+work for a frame.
+
+If the capsule uses an algorithm that benefits from batching,
+this method may call `self.send_to_batch`, which will asynchronously send work
+out for batching. Doing so requires that the `batch_predict` method is
+overridden. See the section on batching methods for more information.
+
+Arguments:
+
+- `frame` A numpy array representing a frame. It is of shape (height, width,
+  channel) and the frames come in BGR order.
+- `detection_node` The detection_node type as specified by the `input_type`
+- `options` A dictionary of key (string) value pairs. The key is the name of a
+  capsule option, and the value is its configured value at the time of
+  processing. Capsule options are specified using the `options` field in the
+  Capsule class.
+- `state` This will be a StreamState object of the type specified by the
+  `stream_state` attribute on the Capsule class. If no StreamState object was
+  specified, a simple BaseStreamState object will be passed in. The StreamState
+  will be the same object for all frames in the same video stream.
+
+### close
+
+```python
+def close(self):
+    ...
+```
+
+The `close` method de-initializes the backend. Once this method is called,
+the backend will no longer be in use.
+
+## Batching Methods
+
+Batching refers to the process of collecting more than one video frame into a
+"batch" and sending them all out for processing at once. Certain algorithms see
+performance improvements when batching is used, because doing so decreases the
+amount of round-trips the video frames take between devices.
+
+If you wish to use batching in your capsule, you may call the `send_to_batch`
+method in `process_frame` instead of doing analysis in that method directly. The
+`send_to_batch` method collects one or more input objects into a list and
+routinely calls your backend's `batch_predict` method with this list. As a
+result, users of `send_to_batch` must override the `batch_predict` method in
+addition to the other required methods.
+
+The `send_to_batch` method is asynchronous. Instead of immediately returning
+analysis results, it returns a `queue.Queue` where the result will be provided.
+Simple batching capsules may call `send_to_batch`, then immediately call `get`
+to block for the result.
+
+```python
+result = self.send_to_batch(frame).get()
+```  
+
+An argument of any type may be provided to `send_to_batch`, as the argument
+will be passed in a list to `batch_predict` without modification. In many cases
+only the video frame needs to be provided, but additional metadata may be
+included as necessary to fit your algorithm's needs.
+
+### batch_predict
+```python
+def batch_predict(self, inputs: List[Any]) -> List[Any]:
+    ...
+```
+
+This method takes in a batch as input and provides a list of result objects of
+any type as output. What the result objects are will depend on the algorithm 
+being defined, but the number of prediction objects returned _must_ match the
+number of video frames provided as input.

--- a/docs/capsule_class.md
+++ b/docs/capsule_class.md
@@ -1,0 +1,117 @@
+## Introduction
+
+The Capsule class provides information to the application about what a capsule
+is and how it should be run. Every capsule defines a Capsule class that extends
+BaseCapsule in its `capsule.py` file.
+
+```python
+from vcap import (
+    BaseCapsule,
+    NodeDescription,
+    options
+)
+
+class Capsule(BaseCapsule):
+    name = "detector_person"
+    version = 1
+    stream_state = StreamState
+    input_type = NodeDescription(size=NodeDescription.Size.NONE),
+    output_type = NodeDescription(
+        size=NodeDescription.Size.ALL,
+        detections=["person"])
+    backend_loader = backend_loader_func
+    options = {
+        "threshold": options.FloatOption(
+            default=0.5,
+            min_val=0.1,
+            max_val=1.0)
+    }
+```
+
+## Fields
+
+### name
+
+```python
+name: str
+```
+
+The name of the capsule. This value uniquely defines the capsule and cannot be
+shared by other capsules. By convention, the capsule's name is prefixed by some
+short description of the role it plays ("detector", "recognizer", etc) followed
+by the kind of data it relates to ("person", "face", etc) and, if necessary,
+some differentiating factor ("fast", "close_up", "retail", etc).
+
+
+### version
+
+```python
+version: int
+```
+
+The incremental version of the capsule. It's recommended to change the version
+on any change of capsule options, algorithms or models.
+
+### device_mapper
+
+```python
+device_mapper: DeviceMapper
+```
+
+A device mapper contains a single field, `filter_func`, which is a function that
+takes in a list of all available device strings and returns a list of device
+strings that are compatible with this capsule.
+
+### stream_state
+
+```python
+stream_state: Type[BaseStreamState]
+```
+(Optional) A class that the application will make instances of for each video
+stream. See [the section on StreamState](../stream_state/) for more information.
+
+### input_type
+
+```python
+input_type: NodeDescription
+```
+
+Describes the types of DetectionNodes that this capsule takes in as input. See
+[the section on inputs and outputs](../inputs_and_outputs/)
+for more information.
+
+### output_type
+
+```python
+output_type: NodeDescription
+```
+
+Describes the types of DetectionNodes that this capsule produces as output. See
+[the section on inputs and outputs](../inputs_and_outputs/)
+for more information.
+
+### backend_loader
+
+```python
+backend_loader: Callable[[dict, str], BaseBackend]
+```
+
+A function that creates a backend for this capsule. Takes the following as
+arguments:
+
+- `capsule_files`: Provides access to all files in the capsule. The keys are
+  file names and the values are `bytes`.
+- `device`: A string specifying the device that this backend should use. For
+  example, the first GPU device is specified as "GPU:0".
+
+The function must return a class that subclasses BaseBackend.
+See [the section on backends](../backends/) for more information.
+
+### options
+
+```python
+options: dict[str, Option]
+```
+
+A dict where the key is an option name and the value is an Option object. See
+[the section on options](../options/) for more information.

--- a/docs/creating_a_capsule.md
+++ b/docs/creating_a_capsule.md
@@ -1,0 +1,59 @@
+For application developers, OpenVisionCapsules provides a function to package up
+unpackaged capsules. The optional `key` field encrypts the capsule with AES.
+
+```python
+from vcap import package_capsule
+
+package_capsule(Path("detector_person"),
+                Path("capsules", "detector_person.cap"),
+                key="[AES Key]")
+```
+
+For capsule developers for an application, it is the job of the application to
+provide a way to package capsules. Please see the documentation for the
+application you are using for more information.
+
+## Creating an Object Detector Capsule with Supervisely
+
+If you’ve trained tensorflow-object-detection-API object detector using
+Supervisely, you can follow the following steps to deploy your model as a
+capsule:
+
+### Set up the TF Object Detection API
+
+First, set up the Tensorflow Object Detection API on your machine by cloning
+the `tensorflow/models` repository and following the object detection API
+installation instructions. Make sure the tests pass before continuing-
+otherwise, you might have forgotten to set up certain environment variables!
+
+### Freeze your trained Supervisely model
+
+Next, you must download your trained Supervisely model and extract it. Inside
+you should see the following directory structure:
+
+```
+    <DOWNLOADED MODEL DIR>
+    ├── config.json
+    ├── model.config
+    └── model_weights
+        ├── checkpoint
+        ├── model.ckpt.data-00000-of-00001
+        ├── model.ckpt.index
+        └── model.ckpt.meta
+```
+
+Now, you must simply freeze the model to get the `frozen_inference_graph.pb`.
+To do that, run `models/research/object_detection/export_inference_graph.py`
+script inside of your downloaded model directory.
+
+```bash
+python PATH/TO/export_inference_graph.py \
+    --input_type image_tensor \
+    --pipeline_config_path model.config \
+    --trained_checkpoint_prefix model_weights/model.ckpt \
+    --output_directory .
+```
+
+There should now be a frozen_inference_graph.pb in the current directory. This
+is the model file that has been optimized for inference, and is much more
+portable for production use. 

--- a/docs/file_structure.md
+++ b/docs/file_structure.md
@@ -1,0 +1,37 @@
+All capsules start off their life as unpackaged capsules. An unpackaged capsule
+is simply a directory containing all files that will be packaged into the
+capsule. This directory must contain, at minimum, a meta.conf file and a
+capsule.py file.
+
+```
+    detector_person
+    ├── meta.conf
+    └── capsule.py
+```
+
+The meta.conf file is a simple configuration file which specifies the major and
+minor version of OpenVisionCapsules that this capsule requires. Applications use
+this information to decide if your capsule is compatible with the version of
+OpenVisionCapsules the application uses. A capsule with a compatibility version
+of 0.1 are expected to be compatible with applications that use
+OpenVisionCapsules version 0.1 through 0.x, but not 1.x or 2.x.
+
+```ini
+[about]
+api_compatibility_version = 0.1
+```
+
+The capsule.py file is the meat of the capsule. It contains the actual behavior
+of the capsule. We will talk more about the contents of this file in a later
+section.
+
+If your capsule uses other files for its operation, like a model file, it should
+be included in this directory as well. All files in the capsule's directory
+will be included and made accessible once it's packaged.
+
+```
+    person_detection_capsule
+    ├── meta.conf
+    ├── capsule.py
+    └── frozen_inference_graph.pb
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# Introduction
+
+This is a guide on how to encapsulate an algorithm using OpenVisionCapsules.
+Capsules are discrete components that define new ways to analyze video streams.
+
+This guide discusses the Open Vision Capsule system generally, not any specific
+information on how to write a Capsule of a certain type or with certain
+technology. Example capsules are available under `vcap/examples` that show how
+to encapsulate models from various popular machine learning frameworks.
+
+# What is a Capsule?
+
+A capsule is a single file with a `.cap` file extension. It contains the code,
+metadata, model files, and any other files the capsule needs to operate.
+
+Capsules take a frame and information from other capsules as input, run some
+kind of analysis, and provide metadata about the frame as output. For example, a
+person detection capsule would take a frame as input and output person
+detections in that frame. A gender classifier capsule would take this frame and
+each person detection as input, and output a male or female classification for
+that detection.
+
+Capsules provide metadata describing these inputs and outputs alongside other
+information on the capsule. Applications that are compatible OpenVisionCapsules
+use this metadata to know when to run the capsule and with what input.

--- a/docs/inputs_and_outputs.md
+++ b/docs/inputs_and_outputs.md
@@ -1,0 +1,247 @@
+## Introduction
+
+Capsules are defined by the data they take as input and the information they
+give as output. Applications use this information to connect capsules to each
+other and schedule their execution. These inputs and outputs are _defined_
+by NodeDescription objects and _realized_ by DetectionNode objects.
+
+## DetectionNode
+
+Capsules use DetectionNode objects to communicate results to other capsules and
+the application itself. A DetectionNode contains information on a detection in
+the current frame. Capsules that detect objects in a frame create new
+DetectionNodes. Capsules that discover attributes about detections add data to
+existing DetectionNodes.
+
+A DetectionNode object contains the following fields:
+
+### class_name
+
+```python
+class_name: str
+```
+
+The detection class name. This describes what the detection is. A detection of
+a person would have a name="person".
+
+### coords
+
+```python
+coords: List[List[int]]
+```
+
+A list of coordinates defining the detection as a polygon in-frame. Comes in
+the format `[[x,y], [x,y]...]`.
+
+
+### attributes
+
+```python
+attributes: Dict[str, str]
+```
+
+A key-value store where the key is the type of attribute being described and
+the value is the attribute's value. For instance, a capsule that detects gender
+might add a "gender" key to this dict, with a value of either "masculine" or
+"feminine".
+
+### encoding
+
+```python
+encoding: Optional[numpy.ndarray]
+```
+
+An array of float values that represent an encoding of the detection. This can
+be used to recognize specific instances of a class. For instance, given a
+picture of person’s face, the encoding of that face and the encodings of future
+faces can be compared to find that person in the future.
+
+### track_id
+
+```python
+track_id: Optional[UUID]
+```
+
+If this object is tracked, this is the unique identifier for this detection
+node that ties it to other detection nodes in future and past frames (within
+the same stream).
+
+### extra_data
+
+```python
+extra_data: Dict[str, object]
+```
+
+A dict of miscellaneous data. This data is provided directly to clients without
+modification, so it’s a good way to pass extra information from a capsule to
+other applications.
+
+### children
+
+```python
+children: List[DetectionNode]
+```
+
+A list of DetectionNode objects that are child detections of this detection.
+For example, a face DetectionNode might be a child of a person DetectionNode.
+
+## NodeDescription
+
+Capsules use NodeDescriptions to describe the kinds of DetectionNodes they
+take in as input and produce as output.
+
+A capsule may take a DetectionNode as input and produce zero or more
+DetectionNodes as output. Capsules define what information inputted
+DetectionNodes must have and what information outputted detection nodes will
+have using NodeDescriptions.
+
+A NodeDescription has the following fields:
+
+### size
+
+```python
+size: NodeDescription.Size
+```
+
+Specifies how many DetectionNodes the capsule takes as input at once.
+
+- `NodeDescription.Size.NONE`: The capsule does not take any input. This is
+  common for capsules that detect objects in frame. These algorithms usually
+  only need the video frame.
+- `NodeDescription.Size.SINGLE`: The capsule takes a single DetectionNode
+  object. This is common for capsules that find attributes for objects that have
+  been detected by other capsules.
+- `NodeDescription.Size.ALL`: The capsule takes all available DetectionNodes
+  that fit the capsule's input requirements. This is common for capsules that
+  track objects between video frames.
+
+### detections
+
+```python
+detections: List[str]
+```
+
+A list of detection class names. This field is used to describe a
+DetectionNodes that have been detected as one of these class names.
+
+For example, a capsule that can encode cars or trucks would use a
+NodeDescription like this as its `input_type`:
+
+```python
+NodeDescription(detections=["car", "truck"])
+```
+
+A capsule that can detect people and dogs would use a NodeDescription like this
+as its `output_type`:
+
+```python
+NodeDescription(detections=["person", "dog"])
+```
+
+### attributes
+
+```python
+attributes: Dict[str, List[str]]
+```
+
+A dict whose key is an attribute name and whose value is all possible values
+for that attribute. This field is used to describe DetectionNodes that has a
+value for every specified attribute.
+
+For example, a capsule that operates on detections that have been classified for
+gender use a NodeDescription like this as its `input_type`:
+
+```python
+NodeDescription(
+    attributes={
+        "gender": ["male", "female"],
+        "color": ["red", "blue", "green"]
+    })
+```
+
+A capsule that can classify people’s gender as either male or female would have
+the following NodeDescription as its `output_type`:
+
+```python
+NodeDescription(
+    detections=["person"],
+    attributes={
+        "gender": ["male", "female"]
+    })
+```
+
+### encoded
+
+```python
+encoded: bool
+```
+
+True if a DetectionNode described by this NodeDescription is encoded.
+
+For example, a capsule that operates on detections of cars that have been
+encoded use a NodeDescription like this as its `input_type`:
+
+```python
+NodeDescription(
+    detections=["car"],
+    encoded=True)
+```
+
+A capsule that encodes people would use a NodeDescription like this as its
+`output_type`:
+
+```python
+NodeDescription(
+    detections=["person"],
+    encoded=True)
+```
+
+### tracked
+
+True if a DetectionNode described by this NodeDescription is encoded.
+
+For example, a capsule that operates on person detections that have been tracked
+would use a NodeDescription like this as its `input_type`.
+
+```python
+NodeDescription(
+    detections=["person"],
+    tracked=True)
+```
+
+A capsule that tracks people would use a NodeDescription like this as its
+`output_type`:
+
+```python
+NodeDescription(
+    detections=["person"],
+    tracked=True)
+```
+
+### extra_data
+
+```python
+extra_data: List[str]
+```
+
+A list of keys in a DetectionNode’s `extra_data` field. This field is used to
+describe DetectionNodes that have a value for every specified `extra_data` key.
+
+For example, a capsule that operates on people detections with a
+"process_extra_fast" `extra_data` field would use a NodeDescription like this
+as its `input_type`:
+
+```python
+NodeDescription(
+    detections=["person"],
+    extra_data=["process_extra_fast"])
+```
+
+A capsule that adds an "is_special" `extra_data` field to its person-detected
+output would use a NodeDescription like this as its `output_type`:
+
+```python
+NodeDescription(
+    detections=["person"],
+    extra_data=["is_special"])
+```

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,48 @@
+## Introduction
+
+Capsules can provide runtime configuration options that change the way the
+capsule operates. These options will appear on the client and can also be
+changed in the UI. Options have a type and constraints that define what values
+are valid.
+
+## FloatOption
+
+An option whose value is a floating point.
+
+| Field Name  | Type  | Description                                          |
+|-------------|-------|------------------------------------------------------|
+| description | str   | The description for this option                      |
+| default     | float | The default value of this option                     |
+| min_val     | float | The minimum allowed value for this option, inclusive |
+| max_val     | float | The maximum allowed value for this option, inclusive |
+
+## IntOption
+
+An option whose value is an integer.
+
+| Field Name  | Type | Description                                          |
+|-------------|------|------------------------------------------------------|
+| description | str  | The description for this option                      |
+| default     | int  | The default value of this option                     |
+| min_val     | int  | The minimum allowed value for this option, inclusive |
+| max_val     | int  | The maximum allowed value for this option, inclusive |
+
+## EnumOption
+
+An option with a discrete set of possible string values. This kind of option
+would be visualized in a UI as a dropdown.
+
+| Field Name  | Type      | Description                                |
+|-------------|-----------|--------------------------------------------|
+| description | str       | The description for this option            |
+| default     | str       | The default value of this option           |
+| choices     | List[str] | A list of all valid values for this option |
+
+## BoolOption
+
+An option whose value is a boolean.
+
+| Field Name  | Type | Description                      |
+|-------------|------|----------------------------------|
+| description | str  | The description for this option  |
+| default     | bool | The default value of this option |

--- a/docs/runtime_environment.md
+++ b/docs/runtime_environment.md
@@ -1,0 +1,51 @@
+## Loading
+
+When a capsule is loaded, the `capsule.py` file is imported as a module and an
+instance of the `Capsule` class defined in that module is instantiated. Then,
+for each compatible device, an instance of the capsule's `Backend` class is
+created using the provided `backend_loader` function.
+
+## Importing
+
+Capsules have access to a number of helpful libraries, including:
+
+- The entirety of the Python standard library
+- Numpy (`import numpy`)
+- OpenCV (`import cv2`)
+- Tensorflow (`import tensorflow`)
+- Scikit Learn (`import sklearn`)
+- OpenVino (`import openvino`)
+
+Applications may provide more libraries in addition to these. Please see that
+application's documentation for more information.
+
+### Importing From Other Files in the Capsule
+
+In order to allow for more complex capsules that have code reuse within them,
+capsules may consist of multiple Python files. These files are made available
+through relative imports.
+
+For example, with the following directory structure:
+
+```
+    capsule_dir/
+    ├── capsule.py
+    ├── backend.py
+    └── utils/
+        ├── img_utils.py
+        └── ml_utils.py
+```
+
+The `capsule.py` file may import the other Python files like so:
+
+```python
+from . import backend
+from .utils import img_utils, ml_utils
+```
+
+Note that non-relative imports to these files will __not__ work:
+
+```python
+import backend
+from utils import img_utils, ml_utils
+```

--- a/docs/stream_state.md
+++ b/docs/stream_state.md
@@ -1,0 +1,16 @@
+It is sometimes desirable to carry state throughout the lifetime of an entire
+video stream, rather than on a frame-by-frame basis. This is where StreamState
+comes in.
+
+If the `stream_state` field of the capsule's Capsule class is set, the
+`process_frame` method for your capsule's backend will be passed an instance of
+the provided class. Any state that should exist for the duration of the video
+stream may be saved here.
+
+This is commonly used by capsules that track objects between video frames.
+Information on previous detections can be stored in the StreamState object and
+read when new detections are found. This can also be useful for result
+smoothing, for caching frames (think RNN models), and many other use cases.
+
+A capsule's StreamState class does not need to implement any methods and has
+no functional purpose outside of the capsule.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: My Docs
+site_name: OpenVisionCapsules Documentation
 theme: readthedocs
 nav:
   - Introduction: "index.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: My Docs
+theme: readthedocs
+nav:
+  - Introduction: "index.md"
+  - File Structure: "file_structure.md"
+  - Runtime Environment: "runtime_environment.md"
+  - The Capsule Class: "capsule_class.md"
+  - Backends: "backends.md"
+  - Inputs and Outputs: "inputs_and_outputs.md"
+  - Options: "options.md"
+  - Creating a Capsule: "creating_a_capsule.md"
+  - Stream State: "stream_state.md"


### PR DESCRIPTION
This is the capsule documentation from BrainFrame, migrated and adapted for this repository. The docs have been adapted to refer to "capsules" instead of "plugins" and talk more generically about an OpenVisionCapsules application instead of BrainFrame.

Resolves #2.